### PR TITLE
Update util.js

### DIFF
--- a/packages/vega-parser/src/util.js
+++ b/packages/vega-parser/src/util.js
@@ -59,9 +59,24 @@ export function sortKey(sort) {
 }
 
 export function aggrField(op, field) {
+  const removeUnnecessary = (str) => {
+    if(str) {
+      s = ''
+      for(i = 0; i < str.length; i++) {
+        if(str[i] !== '\\' && str[i] !== '.' && str[i] !== '[' && str[i] !== ']') {
+          s += str.substring(i,i+1);
+        }
+      }
+      return s;
+    }
+    else {
+      return str;
+    }
+  }
+
   return (op && op.signal ? '$' + op.signal : op || '')
     + (op && field ? '_' : '')
-    + (field && field.signal ? '$' + field.signal : field || '');
+    + (field && field.signal ? '$' + field.signal : removeUnnecessary(field) || '');
 }
 
 // -----


### PR DESCRIPTION
encoding.sort does not seem to work when the field has a dot ([Issue #3225](https://github.com/vega/vega/issues/3255)). It also does not seem to work when there are brackets in the field, for example:

{
  "$schema": "https://vega.github.io/schema/vega-lite/v5.1.0.json",
  "data": {
    "values": [
      {"Continent": "Asia", "Population[": 1367486},
      {"Continent": "Europe", "Population[": 80855},
      {"Continent": "Africa", "Population[": 181563},
      {"Continent": "Oceania", "Population[": 22752},
      {"Continent": "North America", "Population[": 321369},
      {"Continent": "Antarctica", "Population[": 5},
      {"Continent": "South America", "Population[": 204260}
    ]
  },
  "mark": "bar",
  "encoding": {
    "x": {
      "field": "Continent",
      "type": "nominal",
      "sort": {"field": "Population\\[", "order": "descending"}
    },
    "y": {"field": "Population\\[", "type": "quantitative"}
  }
}